### PR TITLE
Update FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
-github: [naveensingh]
+github: [fossifyorg]
 patreon: naveen3singh
 liberapay: naveensingh
-custom: [https://paypal.me/naveen3singh]
+custom: [https://fossify.org/donate]


### PR DESCRIPTION
Now that the GitHub organisation @FossifyOrg accepts sponsors, I propose that the links in the FUNDING.yml of the individual apps should be consistent with the links under https://fossify.org/donate.

Apart from the GitHub Sponsors link I have also changed the custom PayPal link to the general link https://fossify.org/donate. Let me know if you agree with these changes and whether I should create similar PRs for the other repos, or if you'd like to do it the way you want to, on your own.