### PR TITLE
Fixed searching hidden items in copy/move dialog (#144)

### DIFF
--- a/app/src/main/kotlin/org/fossify/gallery/dialogs/PickDirectoryDialog.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/dialogs/PickDirectoryDialog.kt
@@ -159,6 +159,7 @@ class PickDirectoryDialog(
                 }
 
                 activity.runOnUiThread {
+                    allDirectories.clear()
                     gotDirectories(activity.addTempFolderIfNeeded(it))
                 }
             }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [X] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Search wasn't working for displayed hidden folders via button in the dialog.
- It was due to the fact that search was performed on `allDirectories` but it was never updated. After tapping the button, it was only updating `shownDirectories`.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:

https://github.com/FossifyOrg/Gallery/assets/85929121/17d69048-f3a8-4c36-b3e7-32002706aa04

- After:

https://github.com/FossifyOrg/Gallery/assets/85929121/51eaa5b2-b26e-420e-bda7-2ae1471caebd

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #144 

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Gallery/blob/master/CONTRIBUTING.md).
