### PR TITLE
feat: jxl support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,7 @@ dependencies {
     implementation(libs.awebp)
     implementation(libs.apng)
     implementation(libs.avif.integration)
+    implementation(libs.jxl.integration)
     implementation(libs.okio)
     implementation(libs.picasso) {
         exclude(group = "com.squareup.okhttp3", module = "okhttp")

--- a/app/src/main/kotlin/org/fossify/gallery/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/extensions/Context.kt
@@ -542,6 +542,7 @@ fun Context.loadImageBase(
 
     // animation is only supported without rounded corners and the file must be a GIF or WEBP.
     // Glide doesn't support animated AVIF: https://bumptech.github.io/glide/int/avif.html
+    // TODO: animate JXL
     if (animate && roundCorners == ROUNDED_CORNERS_NONE && (path.isGif() || path.isWebP())) {
         // this is required to make glide cache aware of changes
         options.decode(Drawable::class.java)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,6 +69,7 @@ glide-compiler = { module = "com.github.bumptech.glide:ksp", version.ref = "glid
 zjupure-webpdecoder = { module = "com.github.zjupure:webpdecoder", version.ref = "zjupureWebpdecoder" }
 picasso = { module = "com.squareup.picasso:picasso", version.ref = "picasso" }
 avif-integration = { group = "com.github.bumptech.glide", name = "avif-integration", version.ref = "glideCompiler" }
+jxl-integration = { group = "io.github.awxkee", name = "jxl-coder-glide", version = "2.2.0" }
 [bundles]
 room = [
     "androidx-room-ktx",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,8 +10,8 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
-        jcenter()
         mavenCentral()
+        jcenter()
         maven { setUrl("https://jitpack.io") }
     }
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- added JXL (still) decode support

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #3 

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- https://github.com/FossifyOrg/Commons/pull/56

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Gallery/blob/master/CONTRIBUTING.md).

I had to relocate jcenter below mavenCentral. for some reason it refused to pick up jxl-coder-glide without relocating it.

Decoding seems to be rather slower then expected, but still fast enough for general use.