### PR TITLE
Use black placeholder background for thumbnails

### DIFF
--- a/app/src/main/kotlin/org/fossify/gallery/adapters/DirectoryAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/adapters/DirectoryAdapter.kt
@@ -821,6 +821,14 @@ class DirectoryAdapter(
                     else -> ROUNDED_CORNERS_BIG
                 }
 
+                dirThumbnail.setBackgroundResource(
+                    when (roundedCorners) {
+                        ROUNDED_CORNERS_SMALL -> R.drawable.placeholder_rounded_small
+                        ROUNDED_CORNERS_BIG -> R.drawable.placeholder_rounded_big
+                        else -> R.drawable.placeholder_square
+                    }
+                )
+
                 activity.loadImage(
                     type = thumbnailType,
                     path = directory.tmb,

--- a/app/src/main/kotlin/org/fossify/gallery/adapters/MediaAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/adapters/MediaAdapter.kt
@@ -656,6 +656,14 @@ class MediaAdapter(
                 else -> ROUNDED_CORNERS_NONE
             }
 
+            mediumThumbnail.setBackgroundResource(
+                when (roundedCorners) {
+                    ROUNDED_CORNERS_SMALL -> R.drawable.placeholder_rounded_small
+                    ROUNDED_CORNERS_BIG -> R.drawable.placeholder_rounded_big
+                    else -> R.drawable.placeholder_square
+                }
+            )
+
             activity.loadImage(
                 type = medium.type,
                 path = path,

--- a/app/src/main/kotlin/org/fossify/gallery/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/extensions/Context.kt
@@ -558,7 +558,6 @@ fun Context.loadImageBase(
 
     // animation is only supported without rounded corners and the file must be a GIF or WEBP.
     // Glide doesn't support animated AVIF: https://bumptech.github.io/glide/int/avif.html
-    // TODO: animate JXL
     if (animate && roundCorners == ROUNDED_CORNERS_NONE && (path.isGif() || path.isWebP())) {
         // this is required to make glide cache aware of changes
         options.decode(Drawable::class.java)
@@ -629,8 +628,11 @@ fun Context.loadSVG(
         .transition(getOptionalCrossFadeTransition(crossFadeDuration))
 
     if (roundCorners != ROUNDED_CORNERS_NONE) {
-        val cornerSize =
-            if (roundCorners == ROUNDED_CORNERS_SMALL) org.fossify.commons.R.dimen.rounded_corner_radius_small else org.fossify.commons.R.dimen.rounded_corner_radius_big
+        val cornerSize = when (roundCorners) {
+            ROUNDED_CORNERS_SMALL -> org.fossify.commons.R.dimen.rounded_corner_radius_small
+            else -> org.fossify.commons.R.dimen.rounded_corner_radius_big
+        }
+
         val cornerRadius = resources.getDimension(cornerSize).toInt()
         builder = builder.transform(CenterCrop(), RoundedCorners(cornerRadius))
     }

--- a/app/src/main/res/drawable/placeholder_rounded_big.xml
+++ b/app/src/main/res/drawable/placeholder_rounded_big.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/md_grey_black" />
+    <corners android:radius="@dimen/rounded_corner_radius_big" />
+</shape>

--- a/app/src/main/res/drawable/placeholder_rounded_small.xml
+++ b/app/src/main/res/drawable/placeholder_rounded_small.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/md_grey_black" />
+    <corners android:radius="@dimen/rounded_corner_radius_small" />
+</shape>

--- a/app/src/main/res/drawable/placeholder_square.xml
+++ b/app/src/main/res/drawable/placeholder_square.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/md_grey_black" />
+</shape>


### PR DESCRIPTION
Using a black placeholder leads to a clearer thumbnail vs background separation on most themes. This is more apparent when images are being loaded for the first time.

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Updated thumbnail background color
- Minor code improvement

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Gallery/blob/master/CONTRIBUTING.md).
