### PR TITLE
Removed autosaving rotation (#241)

### DIFF
--- a/app/src/main/kotlin/org/fossify/gallery/fragments/PhotoFragment.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/fragments/PhotoFragment.kt
@@ -271,12 +271,6 @@ class PhotoFragment : ViewPagerFragment() {
         }
 
         mLoadZoomableViewHandler.removeCallbacksAndMessages(null)
-        if (mCurrentRotationDegrees != 0) {
-            ensureBackgroundThread {
-                val path = mMedium.path
-                (activity as? BaseSimpleActivity)?.saveRotatedImageToFile(path, path, mCurrentRotationDegrees, false) {}
-            }
-        }
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Removed the code responsible for autosaving rotation.
- Rotation has to be confirmed with tapping a tick and also can be undone by tapping the back button.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:

https://github.com/user-attachments/assets/8a3c4b3b-3702-4179-9d05-e58d298c4bfd

- After:

https://github.com/user-attachments/assets/9292dfda-ee4c-4b94-bb9a-b4c44a8c7447

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #241 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Gallery/blob/master/CONTRIBUTING.md).
