### PR TITLE
Implement internal cropping instead of library's built-in function

### DIFF
--- a/app/src/main/kotlin/org/fossify/gallery/activities/EditActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/EditActivity.kt
@@ -10,9 +10,12 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.provider.MediaStore
+import android.view.View
 import android.widget.ImageView
 import android.widget.RelativeLayout
+import androidx.core.view.isInvisible
 import androidx.exifinterface.media.ExifInterface
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DataSource
@@ -25,6 +28,7 @@ import com.bumptech.glide.request.target.Target
 import com.canhub.cropper.CropImageView
 import com.zomato.photofilters.FilterPack
 import com.zomato.photofilters.imageprocessors.Filter
+import kotlinx.coroutines.*
 import org.fossify.commons.dialogs.ColorPickerDialog
 import org.fossify.commons.extensions.*
 import org.fossify.commons.helpers.NavigationIcon
@@ -87,6 +91,7 @@ class EditActivity : SimpleActivity(), CropImageView.OnCropImageCompleteListener
     private var oldExif: ExifInterface? = null
     private var filterInitialBitmap: Bitmap? = null
     private var originalUri: Uri? = null
+    private var bitmapCroppingJob: Job? = null
     private val binding by viewBinding(ActivityEditBinding::inflate)
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -313,7 +318,7 @@ class EditActivity : SimpleActivity(), CropImageView.OnCropImageCompleteListener
         setOldExif()
 
         if (binding.cropImageView.isVisible()) {
-            binding.cropImageView.croppedImageAsync()
+            cropImageAsync()
         } else if (binding.editorDrawCanvas.isVisible()) {
             val bitmap = binding.editorDrawCanvas.getBitmap()
             if (saveUri.scheme == "file") {
@@ -348,6 +353,26 @@ class EditActivity : SimpleActivity(), CropImageView.OnCropImageCompleteListener
                     }
                 }
             }
+        }
+    }
+
+    private fun setCropProgressBarVisibility(visible: Boolean) {
+        val progressBar: View? = binding.cropImageView.findViewById(com.canhub.cropper.R.id.CropProgressBar)
+        progressBar?.isInvisible = visible.not()
+    }
+
+    private fun cropImageAsync() {
+        setCropProgressBarVisibility(visible = true)
+        bitmapCroppingJob?.cancel()
+        bitmapCroppingJob = lifecycleScope.launch(CoroutineExceptionHandler { _, t ->
+            onCropImageComplete(bitmap = null, error = Exception(t))
+        }) {
+            val bitmap = withContext(Dispatchers.Default) {
+                binding.cropImageView.getCroppedImage()
+            }
+            onCropImageComplete(bitmap, null)
+        }.apply {
+            invokeOnCompletion { setCropProgressBarVisibility(visible = false) }
         }
     }
 
@@ -764,7 +789,7 @@ class EditActivity : SimpleActivity(), CropImageView.OnCropImageCompleteListener
         ResizeDialog(this, point) {
             resizeWidth = it.x
             resizeHeight = it.y
-            binding.cropImageView.croppedImageAsync()
+            cropImageAsync()
         }
     }
 
@@ -793,10 +818,13 @@ class EditActivity : SimpleActivity(), CropImageView.OnCropImageCompleteListener
     }
 
     override fun onCropImageComplete(view: CropImageView, result: CropImageView.CropResult) {
-        if (result.error == null && result.bitmap != null) {
+        onCropImageComplete(result.bitmap, result.error)
+    }
+
+    private fun onCropImageComplete(bitmap: Bitmap?, error: Exception?) {
+        if (error == null && bitmap != null) {
             setOldExif()
 
-            val bitmap = result.bitmap!!
             if (isSharingBitmap) {
                 isSharingBitmap = false
                 shareBitmap(bitmap)
@@ -843,7 +871,7 @@ class EditActivity : SimpleActivity(), CropImageView.OnCropImageCompleteListener
                 toast(R.string.unknown_file_location)
             }
         } else {
-            toast("${getString(R.string.image_editing_failed)}: ${result.error?.message}")
+            toast("${getString(R.string.image_editing_failed)}: ${error?.message}")
         }
     }
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Fix saving an unnecessary copy when cropping and resizing a picture.
- Reuse the library's built-in progress bar to indicate the cropping process.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before: 

https://github.com/user-attachments/assets/bda1ce4b-45fb-4787-ac78-03cc15f31e3d


- After: 

https://github.com/user-attachments/assets/f06eb48d-3590-4579-87b7-81221af89218


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes https://github.com/FossifyOrg/Gallery/issues/378


#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Gallery/blob/master/CONTRIBUTING.md).
