### PR TITLE
ACTION_GET_CONTENT with multiple MIME types

### DIFF
--- a/app/src/main/kotlin/org/fossify/gallery/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/MainActivity.kt
@@ -599,10 +599,10 @@ class MainActivity : SimpleActivity(), DirectoryOperationsListener {
 
         mShouldStopFetching = true
         mIsGettingDirs = true
-        val getImagesOnly = mIsPickImageIntent || mIsGetImageContentIntent
-        val getVideosOnly = mIsPickVideoIntent || mIsGetVideoContentIntent
+        val getImages = mIsPickImageIntent || mIsGetImageContentIntent
+        val getVideos = mIsPickVideoIntent || mIsGetVideoContentIntent
 
-        getCachedDirectories(getVideosOnly, getImagesOnly) {
+        getCachedDirectories(getVideos && !getImages, getImages && !getVideos) {
             gotDirectories(addTempFolderIfNeeded(it))
         }
     }
@@ -890,10 +890,10 @@ class MainActivity : SimpleActivity(), DirectoryOperationsListener {
     private fun isGetContentIntent(intent: Intent) = intent.action == Intent.ACTION_GET_CONTENT && intent.type != null
 
     private fun isGetImageContentIntent(intent: Intent) = isGetContentIntent(intent) &&
-        (intent.type!!.startsWith("image/") || intent.type == Images.Media.CONTENT_TYPE)
+        (intent.type!!.split(",", "|").any { it.startsWith("image/") } || intent.type == Images.Media.CONTENT_TYPE)
 
     private fun isGetVideoContentIntent(intent: Intent) = isGetContentIntent(intent) &&
-        (intent.type!!.startsWith("video/") || intent.type == Video.Media.CONTENT_TYPE)
+        (intent.type!!.split(",", "|").any { it.startsWith("video/") } || intent.type == Video.Media.CONTENT_TYPE)
 
     private fun isGetAnyContentIntent(intent: Intent) = isGetContentIntent(intent) && intent.type == "*/*"
 


### PR DESCRIPTION
Some apps provide multiple MIME types separated by either comma or pipe.

Without this, image/*,video/* only shows videos.

<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Parse ACTION_GET_CONTENT multiple intents
- Handle case of both mIsGetImageContentIntent && mIsGetVideoContentIntent

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Gallery/blob/master/CONTRIBUTING.md).
