### PR TITLE
Fix issue with physical keyboards in copy/move dialog

### DIFF
--- a/app/src/main/kotlin/org/fossify/gallery/dialogs/PickDirectoryDialog.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/dialogs/PickDirectoryDialog.kt
@@ -1,7 +1,8 @@
 package org.fossify.gallery.dialogs
 
 import android.graphics.Color
-import android.view.KeyEvent
+import android.view.KeyEvent.ACTION_UP
+import android.view.KeyEvent.KEYCODE_BACK
 import android.view.inputmethod.EditorInfo
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
@@ -54,10 +55,12 @@ class PickDirectoryDialog(
             .setPositiveButton(org.fossify.commons.R.string.ok, null)
             .setNegativeButton(org.fossify.commons.R.string.cancel, null)
             .setOnKeyListener { dialogInterface, i, keyEvent ->
-                if (keyEvent.action == KeyEvent.ACTION_UP && i == KeyEvent.KEYCODE_BACK) {
+                return@setOnKeyListener if (keyEvent.action == ACTION_UP && i == KEYCODE_BACK) {
                     backPressed()
+                    true
+                } else {
+                    false
                 }
-                true
             }
 
         if (showOtherFolderButton) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR

 - Returned `false` when key event was not handled. 
 
The dialog's key listener was consuming all key events and led to problems like https://github.com/FossifyOrg/Gallery/issues/128.

It' a bit overkill to use a whole app bar layout with menus and all here, should be reworked.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #128

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Gallery/blob/master/CONTRIBUTING.md).
