### PR TITLE
fix(player): change seek parameters to EXACT for precise playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed inaccurate seeking in some videos ([#475])
+
 ## [1.2.1] - 2024-09-28
 
 ### Added
+
 - Added option to control video playback speed
 - Added option to mute videos
 - Added error indicator for media load failures
 - Added initial support for JPEG XL format (increased app size)
 
 ### Changed
+
 - Updated target Android version to 14
 - Replaced checkboxes with switches
 - Improve scrolling performance and interface
@@ -26,12 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] - 2024-09-21
 
 ### Added
+
 - Added option to control video playback speed
 - Added option to mute videos
 - Added error indicator for media load failures
 - Added initial support for JPEG XL format
 
 ### Changed
+
 - Updated target Android version to 14
 - Replaced checkboxes with switches
 - Improved app lock logic and user interface
@@ -41,20 +49,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.3] - 2024-04-16
 
 ### Changed
+
 - Added some translations
 
 ### Fixed
+
 - Fixed black thumbnails for some images.
 
 ## [1.1.2] - 2024-03-10
 
 ### Added
+
 - Added support for AVIF.
 
 ### Changed
+
 - Added some translations
 
 ### Fixed
+
 - Fixed crash when playing videos.
 - Fixed slideshow on Android 14.
 - Fixed position reset after device rotation.
@@ -63,33 +76,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.1] - 2024-01-10
 
 ### Changed
+
 - Added some translations
 
 ### Removed
+
 - Removed fake app message when using the editor.
 
 ## [1.1.0] - 2024-01-02
 
 ### Changed
+
 - Added some translations
 
 ### Removed
+
 - Removed proprietary panorama library
 
 ## [1.0.2] - 2023-12-30
 
 ### Changed
+
 - Added some translations
 
 ### Fixed
+
 - Fixed zooming in high-res images
 
 ## [1.0.1] - 2023-12-28
 
 ### Changed
+
 - Added some translation, UI/UX improvements
 
 ### Fixed
+
 - Fixed privacy policy link
 
 [Unreleased]: https://github.com/FossifyOrg/Gallery/compare/1.2.1...HEAD
@@ -101,3 +122,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://github.com/FossifyOrg/Gallery/compare/1.0.2...1.1.0
 [1.0.2]: https://github.com/FossifyOrg/Gallery/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/FossifyOrg/Gallery/releases/tag/1.0.1
+
+[#475]: https://github.com/FossifyOrg/Gallery/issues/475

--- a/app/src/main/kotlin/org/fossify/gallery/activities/VideoPlayerActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/VideoPlayerActivity.kt
@@ -348,7 +348,7 @@ open class VideoPlayerActivity : SimpleActivity(), SeekBar.OnSeekBarChangeListen
 
         mExoPlayer = ExoPlayer.Builder(this)
             .setMediaSourceFactory(DefaultMediaSourceFactory(applicationContext))
-            .setSeekParameters(SeekParameters.CLOSEST_SYNC)
+            .setSeekParameters(SeekParameters.EXACT)
             .setLoadControl(loadControl)
             .build()
             .apply {

--- a/app/src/main/kotlin/org/fossify/gallery/fragments/VideoFragment.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/fragments/VideoFragment.kt
@@ -462,7 +462,7 @@ class VideoFragment : ViewPagerFragment(), TextureView.SurfaceTextureListener,
 
         mExoPlayer = ExoPlayer.Builder(requireContext())
             .setMediaSourceFactory(DefaultMediaSourceFactory(requireContext()))
-            .setSeekParameters(SeekParameters.CLOSEST_SYNC)
+            .setSeekParameters(SeekParameters.EXACT)
             .setLoadControl(loadControl)
             .build()
             .apply {


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Switched to exact seeking. This helps avoid jumping back to start in special videos with just one keyframe (see [#475](https://github.com/FossifyOrg/Gallery/issues/475) for example).

#### Fixes the following issue(s)
- Fixes #475 
- Partly addresses #325 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I manually tested my changes on device/emulator (if applicable).