### PR TITLE
 Added restore confirmation dialogs (#447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added restore confirmation dialogs ([#447])
+
 ## [1.2.1] - 2024-09-28
 
 ### Added

--- a/app/src/main/kotlin/org/fossify/gallery/activities/MediaActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/MediaActivity.kt
@@ -83,6 +83,7 @@ import org.fossify.gallery.extensions.openPath
 import org.fossify.gallery.extensions.openRecycleBin
 import org.fossify.gallery.extensions.restoreRecycleBinPaths
 import org.fossify.gallery.extensions.showRecycleBinEmptyingDialog
+import org.fossify.gallery.extensions.showRecycleBinRestoringAllDialog
 import org.fossify.gallery.extensions.tryDeleteFileDirItem
 import org.fossify.gallery.extensions.updateWidgets
 import org.fossify.gallery.helpers.DIRECTORY
@@ -597,12 +598,14 @@ class MediaActivity : SimpleActivity(), MediaOperationsListener {
     }
 
     private fun restoreAllFiles() {
-        val paths = mMedia.filter { it is Medium }.map { (it as Medium).path } as ArrayList<String>
-        restoreRecycleBinPaths(paths) {
-            ensureBackgroundThread {
-                directoryDB.deleteDirPath(RECYCLE_BIN)
+        showRecycleBinRestoringAllDialog {
+            val paths = mMedia.filter { it is Medium }.map { (it as Medium).path } as ArrayList<String>
+            restoreRecycleBinPaths(paths) {
+                ensureBackgroundThread {
+                    directoryDB.deleteDirPath(RECYCLE_BIN)
+                }
+                finish()
             }
-            finish()
         }
     }
 

--- a/app/src/main/kotlin/org/fossify/gallery/adapters/MediaAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/adapters/MediaAdapter.kt
@@ -72,6 +72,7 @@ import org.fossify.gallery.extensions.saveRotatedImageToFile
 import org.fossify.gallery.extensions.setAs
 import org.fossify.gallery.extensions.shareMediaPaths
 import org.fossify.gallery.extensions.shareMediumPath
+import org.fossify.gallery.extensions.showRecycleBinRestoringSelectedDialog
 import org.fossify.gallery.extensions.toggleFileVisibility
 import org.fossify.gallery.extensions.tryCopyMoveFilesTo
 import org.fossify.gallery.extensions.updateDBMediaPath
@@ -388,7 +389,18 @@ class MediaAdapter(
     }
 
     private fun restoreFiles() {
-        activity.restoreRecycleBinPaths(getSelectedPaths()) {
+        val paths = getSelectedPaths()
+        if (paths.size > 1) {
+            activity.showRecycleBinRestoringSelectedDialog {
+                doRestoreFiles(paths)
+            }
+        } else {
+            doRestoreFiles(paths)
+        }
+    }
+
+    private fun doRestoreFiles(paths: ArrayList<String>) {
+        activity.restoreRecycleBinPaths(paths) {
             listener?.refreshItems()
             finishActMode()
         }

--- a/app/src/main/kotlin/org/fossify/gallery/extensions/Activity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/extensions/Activity.kt
@@ -504,6 +504,30 @@ fun BaseSimpleActivity.showRecycleBinEmptyingDialog(callback: () -> Unit) {
     }
 }
 
+fun BaseSimpleActivity.showRecycleBinRestoringSelectedDialog(callback: () -> Unit) {
+    ConfirmationDialog(
+        this,
+        "",
+        R.string.restore_all_selected_confirmation,
+        org.fossify.commons.R.string.yes,
+        org.fossify.commons.R.string.no
+    ) {
+        callback()
+    }
+}
+
+fun BaseSimpleActivity.showRecycleBinRestoringAllDialog(callback: () -> Unit) {
+    ConfirmationDialog(
+        this,
+        "",
+        R.string.restore_all_confirmation,
+        org.fossify.commons.R.string.yes,
+        org.fossify.commons.R.string.no
+    ) {
+        callback()
+    }
+}
+
 fun BaseSimpleActivity.updateFavoritePaths(fileDirItems: ArrayList<FileDirItem>, destination: String) {
     ensureBackgroundThread {
         fileDirItems.forEach {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,8 @@
     <string name="reorder_by_dragging">Reorder folders by dragging</string>
     <string name="reorder_by_dragging_pro">Reorder folders by dragging (Pro)</string>
     <string name="restore_to_path">Restoring to \'%s\'</string>
+    <string name="restore_all_selected_confirmation">Are you sure you want to restore all selected files?</string>
+    <string name="restore_all_confirmation">Are you sure you want to restore all files?</string>
     <string name="full_storage_permission_required">Fossify Gallery needs full access to display all your photos and videos. Go to Settings > Permissions > Photos and videos > Allow all.</string>
 
     <!-- Filter -->


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Added two confirmation dialogs - for restoring all files and restoring selected files.
- For selected files, dialog is only displayed if there are multiple files (per https://github.com/FossifyOrg/Gallery/issues/447#issuecomment-2841041013).

#### Before/After Screenshots/Screen Record
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->

https://github.com/user-attachments/assets/241b559f-cdda-4d9a-bc74-98cefb7aeec0

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). -->
- Fixes #447

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I manually tested my changes on device/emulator (if applicable).

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
