### PR TITLE
feat: add Ultra HDR JPEG support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,6 +105,7 @@
         <activity
             android:name=".activities.ViewPagerActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
+            android:colorMode="hdr"
             android:exported="true"
             android:parentActivityName=".activities.MediaActivity"
             android:theme="@style/TranslucentTheme">
@@ -150,6 +151,7 @@
         <activity
             android:name=".activities.PhotoVideoActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
+            android:colorMode="hdr"
             android:exported="false"
             android:theme="@style/TranslucentTheme" />
 
@@ -184,6 +186,7 @@
         <activity
             android:name=".activities.PhotoActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
+            android:colorMode="hdr"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/kotlin/org/fossify/gallery/helpers/UltraHDRDecoder.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/helpers/UltraHDRDecoder.kt
@@ -1,0 +1,95 @@
+package org.fossify.gallery.helpers
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.Build
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.ResourceDecoder
+import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
+import com.bumptech.glide.load.resource.bitmap.BitmapResource
+import java.io.InputStream
+
+/**
+ * Glide decoder for JPEG Ultra HDR images.
+ * This decoder checks if the image contains a Gainmap and handles it appropriately.
+ */
+class UltraHDRDecoder(
+    private val bitmapPool: BitmapPool
+) : ResourceDecoder<InputStream, Bitmap> {
+
+    override fun handles(source: InputStream, options: Options): Boolean {
+        // Only handle on Android 14+ where Ultra HDR is supported
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+    }
+
+    override fun decode(
+        source: InputStream,
+        width: Int,
+        height: Int,
+        options: Options
+    ): Resource<Bitmap>? {
+        val bitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            // Decode with potential Ultra HDR support
+            val bitmapOptions = BitmapFactory.Options().apply {
+                // Set requested dimensions
+                if (width > 0 && height > 0) {
+                    inJustDecodeBounds = true
+                    BitmapFactory.decodeStream(source, null, this)
+
+                    inSampleSize = calculateInSampleSize(this, width, height)
+                    inJustDecodeBounds = false
+
+                    // Reset stream for actual decoding
+                    source.reset()
+                }
+            }
+
+            val decodedBitmap = BitmapFactory.decodeStream(source, null, bitmapOptions)
+
+            // Check if the bitmap has a Gainmap (Ultra HDR)
+            decodedBitmap?.let {
+                if (it.hasGainmap()) {
+                    // The system will automatically apply the Gainmap
+                    // when displayed in an HDR-capable context
+                    it
+                } else {
+                    it
+                }
+            }
+        } else {
+            // Fallback for older Android versions
+            BitmapFactory.decodeStream(source)
+        }
+
+        return if (bitmap != null) {
+            BitmapResource(bitmap, bitmapPool)
+        } else {
+            null
+        }
+    }
+
+    private fun calculateInSampleSize(
+        options: BitmapFactory.Options,
+        reqWidth: Int,
+        reqHeight: Int
+    ): Int {
+        // Raw height and width of image
+        val height = options.outHeight
+        val width = options.outWidth
+        var inSampleSize = 1
+
+        if (height > reqHeight || width > reqWidth) {
+            val halfHeight = height / 2
+            val halfWidth = width / 2
+
+            // Calculate the largest inSampleSize value that is a power of 2 and keeps both
+            // height and width larger than the requested height and width.
+            while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+                inSampleSize *= 2
+            }
+        }
+
+        return inSampleSize
+    }
+}

--- a/app/src/main/kotlin/org/fossify/gallery/svg/SvgModule.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/svg/SvgModule.kt
@@ -1,20 +1,25 @@
 package org.fossify.gallery.svg
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.drawable.PictureDrawable
-
 import com.bumptech.glide.Glide
 import com.bumptech.glide.Registry
 import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.module.AppGlideModule
 import com.caverock.androidsvg.SVG
-
+import org.fossify.gallery.helpers.UltraHDRDecoder
 import java.io.InputStream
 
 @GlideModule
 class SvgModule : AppGlideModule() {
     override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
-        registry.register(SVG::class.java, PictureDrawable::class.java, SvgDrawableTranscoder()).append(InputStream::class.java, SVG::class.java, SvgDecoder())
+        // Register SVG support
+        registry.register(SVG::class.java, PictureDrawable::class.java, SvgDrawableTranscoder())
+            .append(InputStream::class.java, SVG::class.java, SvgDecoder())
+
+        // Register Ultra HDR support (prepend to handle before default decoders)
+        registry.prepend(InputStream::class.java, Bitmap::class.java, UltraHDRDecoder(glide.bitmapPool))
     }
 
     override fun isManifestParsingEnabled() = false


### PR DESCRIPTION
## Summary
- Add support for Ultra HDR JPEG images on Android 14+ devices
- Enable HDR color mode in photo viewing activities for proper HDR display
- Implement custom Glide decoder to handle JPEG images with Gainmap

## Changes
- Added `UltraHDRDecoder` class that detects and properly handles Ultra HDR JPEG images
- Enabled `android:colorMode="hdr"` in photo viewing activities (ViewPagerActivity, PhotoVideoActivity, PhotoActivity)
- Registered the Ultra HDR decoder in Glide module to handle images before default decoders

## Technical Details
- The decoder only activates on Android 14+ (API 34+) where Ultra HDR is supported
- Uses `Bitmap.hasGainmap()` to detect Ultra HDR images
- The system automatically applies the Gainmap when displayed in an HDR-capable context
- Maintains backward compatibility for older Android versions

## Test plan
- [ ] Test viewing regular JPEG images on Android 14+ devices
- [ ] Test viewing Ultra HDR JPEG images on HDR-capable Android 14+ devices
- [ ] Verify HDR tone mapping works correctly
- [ ] Test on older Android versions to ensure backward compatibility
- [ ] Verify no performance regression when loading images