### PR TITLE
fix(image-view): respect EXIF orientation for mirrored images

### DIFF
--- a/app/src/main/kotlin/org/fossify/gallery/fragments/PhotoFragment.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/fragments/PhotoFragment.kt
@@ -714,7 +714,13 @@ class PhotoFragment : ViewPagerFragment() {
         }
 
         val regionDecoder = object : DecoderFactory<ImageRegionDecoder> {
-            override fun make() = PicassoRegionDecoder(showHighestQuality, mScreenWidth, mScreenHeight, minTileDpi, mImageOrientation)
+            override fun make() = PicassoRegionDecoder(
+                showHighestQuality = showHighestQuality,
+                screenWidth = mScreenWidth,
+                screenHeight = mScreenHeight,
+                minTileDpi = minTileDpi,
+                orientation = mImageOrientation
+            )
         }
 
         var newOrientation = (rotation + mCurrentRotationDegrees) % 360

--- a/app/src/main/kotlin/org/fossify/gallery/fragments/PhotoFragment.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/fragments/PhotoFragment.kt
@@ -714,7 +714,7 @@ class PhotoFragment : ViewPagerFragment() {
         }
 
         val regionDecoder = object : DecoderFactory<ImageRegionDecoder> {
-            override fun make() = PicassoRegionDecoder(showHighestQuality, mScreenWidth, mScreenHeight, minTileDpi)
+            override fun make() = PicassoRegionDecoder(showHighestQuality, mScreenWidth, mScreenHeight, minTileDpi, mImageOrientation)
         }
 
         var newOrientation = (rotation + mCurrentRotationDegrees) % 360

--- a/app/src/main/kotlin/org/fossify/gallery/helpers/PicassoRegionDecoder.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/helpers/PicassoRegionDecoder.kt
@@ -37,7 +37,7 @@ class PicassoRegionDecoder(
             val options = BitmapFactory.Options()
             options.inSampleSize = newSampleSize
             options.inPreferredConfig = Bitmap.Config.ARGB_8888
-            var bitmap = decoder!!.decodeRegion(rect, options)
+            val bitmap = decoder!!.decodeRegion(rect, options)
             if (bitmap == null) {
                 throw RuntimeException("Region decoder returned null bitmap - image format may not be supported")
             }

--- a/app/src/main/kotlin/org/fossify/gallery/helpers/PicassoRegionDecoder.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/helpers/PicassoRegionDecoder.kt
@@ -43,28 +43,21 @@ class PicassoRegionDecoder(
                 throw RuntimeException("Region decoder returned null bitmap - image format may not be supported")
             }
 
-            // Apply EXIF mirror flips (orientation 2,4,5,7)
-            val needsFlipHorizontal =
-                orientation == ExifInterface.ORIENTATION_FLIP_HORIZONTAL ||
-                    orientation == ExifInterface.ORIENTATION_TRANSPOSE ||
-                    orientation == ExifInterface.ORIENTATION_TRANSVERSE
-            val needsFlipVertical = orientation == ExifInterface.ORIENTATION_FLIP_VERTICAL
-
-            if (needsFlipHorizontal || needsFlipVertical) {
-                val matrix = Matrix().apply {
-                    preScale(if (needsFlipHorizontal) -1f else 1f, if (needsFlipVertical) -1f else 1f)
-                    if (needsFlipHorizontal) {
-                        postTranslate(bitmap.width.toFloat(), 0f)
-                    }
-                    if (needsFlipVertical) {
-                        postTranslate(0f, bitmap.height.toFloat())
-                    }
-                }
-                bitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
-            }
-
-            return bitmap
+            return applyExifOrientation(bitmap, orientation)
         }
+    }
+
+    private fun applyExifOrientation(bitmap: Bitmap, orientation: Int): Bitmap {
+        val matrix = Matrix()
+        when (orientation) {
+            ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.setScale(-1f, 1f)
+            ExifInterface.ORIENTATION_FLIP_VERTICAL -> matrix.setScale(1f, -1f)
+            ExifInterface.ORIENTATION_TRANSPOSE -> matrix.setScale(-1f, 1f)
+            ExifInterface.ORIENTATION_TRANSVERSE -> matrix.setScale(-1f, 1f)
+            else -> return bitmap // other cases are handled at the view level
+        }
+
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
     }
 
     override fun isReady() = decoder != null && !decoder!!.isRecycled

--- a/app/src/main/kotlin/org/fossify/gallery/helpers/PicassoRegionDecoder.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/helpers/PicassoRegionDecoder.kt
@@ -23,6 +23,7 @@ class PicassoRegionDecoder(
         return Point(decoder!!.width, decoder!!.height)
     }
 
+    @Suppress("CyclomaticComplexMethod")
     override fun decodeRegion(rect: Rect, sampleSize: Int): Bitmap {
         synchronized(decoderLock) {
             var newSampleSize = sampleSize
@@ -43,7 +44,10 @@ class PicassoRegionDecoder(
             }
 
             // Apply EXIF mirror flips (orientation 2,4,5,7)
-            val needsFlipHorizontal = orientation == ExifInterface.ORIENTATION_FLIP_HORIZONTAL || orientation == ExifInterface.ORIENTATION_TRANSPOSE || orientation == ExifInterface.ORIENTATION_TRANSVERSE
+            val needsFlipHorizontal =
+                orientation == ExifInterface.ORIENTATION_FLIP_HORIZONTAL ||
+                    orientation == ExifInterface.ORIENTATION_TRANSPOSE ||
+                    orientation == ExifInterface.ORIENTATION_TRANSVERSE
             val needsFlipVertical = orientation == ExifInterface.ORIENTATION_FLIP_VERTICAL
 
             if (needsFlipHorizontal || needsFlipVertical) {

--- a/app/src/main/kotlin/org/fossify/gallery/helpers/PicassoRegionDecoder.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/helpers/PicassoRegionDecoder.kt
@@ -23,7 +23,6 @@ class PicassoRegionDecoder(
         return Point(decoder!!.width, decoder!!.height)
     }
 
-    @Suppress("CyclomaticComplexMethod")
     override fun decodeRegion(rect: Rect, sampleSize: Int): Bitmap {
         synchronized(decoderLock) {
             var newSampleSize = sampleSize


### PR DESCRIPTION
Pass image orientation to `PicassoRegionDecoder` and apply necessary transformations (horizontal/vertical flips) to the decoded bitmap region if indicated by EXIF orientation tags (2, 4, 5, 7).

This ensures that images with mirrored EXIF orientations are displayed correctly in the zoomed-in view.

---

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Applied EXIF orientation handling in `PicassoRegionDecoder` for tags 2, 4, 5, and 7.
- Ensures correct display of flipped/mirrored images in zoomed views.

#### Before/After Screenshots/Screen Record
N/A – no visible UI changes in the main interface, only affects image correctness in zoomed-in mode.

#### Closes the following issue(s)
N/A – This pull request is not linked to any existing issue.

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.
