### PR TITLE
fix: do volume gesture math using floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed media picker showing only GIFs when both images and videos are requested
+- Fixed volume gesture not working on some devices ([#237])
 
 ## [1.4.1] - 2025-07-22
 ### Changed
@@ -130,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#128]: https://github.com/FossifyOrg/Gallery/issues/128
 [#166]: https://github.com/FossifyOrg/Gallery/issues/166
 [#199]: https://github.com/FossifyOrg/Gallery/issues/199
+[#237]: https://github.com/FossifyOrg/Gallery/issues/237
 [#241]: https://github.com/FossifyOrg/Gallery/issues/241
 [#275]: https://github.com/FossifyOrg/Gallery/issues/275
 [#325]: https://github.com/FossifyOrg/Gallery/issues/325

--- a/app/src/main/kotlin/org/fossify/gallery/views/MediaSideScroll.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/views/MediaSideScroll.kt
@@ -15,6 +15,7 @@ import org.fossify.commons.extensions.onGlobalLayout
 import org.fossify.gallery.R
 import org.fossify.gallery.extensions.audioManager
 import org.fossify.gallery.helpers.DRAG_THRESHOLD
+import kotlin.math.max
 
 // allow horizontal swipes through the layout, else it can cause glitches at zoomed in images
 class MediaSideScroll(context: Context, attrs: AttributeSet) : RelativeLayout(context, attrs) {
@@ -156,14 +157,9 @@ class MediaSideScroll(context: Context, attrs: AttributeSet) : RelativeLayout(co
 
     private fun volumePercentChanged(percent: Int) {
         val stream = AudioManager.STREAM_MUSIC
-        val maxVolume = activity!!.audioManager.getStreamMaxVolume(stream)
-        val percentPerPoint = 100 / maxVolume
-        if (percentPerPoint == 0) {
-            return
-        }
-
-        val addPoints = percent / percentPerPoint
-        val newVolume = Math.min(maxVolume, Math.max(0, mTouchDownValue + addPoints))
+        val maxVolume = max(activity!!.audioManager.getStreamMaxVolume(stream), 1)
+        val addPoints = ((percent / 100f) * maxVolume).toInt()
+        val newVolume = (mTouchDownValue + addPoints).coerceIn(0, maxVolume)
         activity!!.audioManager.setStreamVolume(stream, newVolume, 0)
 
         val absolutePercent = ((newVolume / maxVolume.toFloat()) * 100).toInt()


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
Some devices return maximum stream volume above 100, and that led to early exit due to integer division + the condition introduced in cf3e27a25dc225fbf0b422db25bfcda579c46372

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Gallery/issues/237

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
