### PR TITLE
fix: fallback to glide on avif load failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed black screen when viewing edited AVIF images ([#648])
 
 ## [1.5.1] - 2025-09-08
 ### Fixed
@@ -167,6 +169,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#567]: https://github.com/FossifyOrg/Gallery/issues/567
 [#621]: https://github.com/FossifyOrg/Gallery/issues/621
 [#642]: https://github.com/FossifyOrg/Gallery/issues/642
+[#648]: https://github.com/FossifyOrg/Gallery/issues/648
 
 [Unreleased]: https://github.com/FossifyOrg/Gallery/compare/1.5.1...HEAD
 [1.5.1]: https://github.com/FossifyOrg/Gallery/compare/1.5.0...1.5.1

--- a/app/src/main/kotlin/org/fossify/gallery/fragments/PhotoFragment.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/fragments/PhotoFragment.kt
@@ -472,6 +472,11 @@ class PhotoFragment : ViewPagerFragment() {
     private fun loadAVIF() {
         if (context != null) {
             val drawable = AVIFDrawable.fromFile(mMedium.path)
+            if (drawable.intrinsicWidth == 0 || drawable.intrinsicHeight == 0) {
+                loadBitmap()
+                return
+            }
+
             binding.gesturesView.setImageDrawable(drawable)
         }
     }
@@ -502,11 +507,14 @@ class PhotoFragment : ViewPagerFragment() {
             .priority(priority)
             .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
             .fitCenter()
-
-        if (mCurrentRotationDegrees != 0) {
-            options.transform(Rotate(mCurrentRotationDegrees))
-            options.diskCacheStrategy(DiskCacheStrategy.NONE)
-        }
+            .run {
+                if (mCurrentRotationDegrees != 0) {
+                    transform(Rotate(mCurrentRotationDegrees))
+                    .diskCacheStrategy(DiskCacheStrategy.NONE)
+                } else {
+                    this
+                }
+            }
 
         Glide.with(requireContext())
             .load(path)


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Glide's integration is more lenient and allows loading JPEGs incorrectly labeled as AVIF. This is why it worked <= v1.5.0.
- This is a quick fix for https://github.com/FossifyOrg/Gallery/issues/648. The root cause is tracked in https://github.com/FossifyOrg/Gallery/issues/649

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Gallery/issues/648

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
