### PR TITLE
fix: disable layout animation in viewpager fragments

### DIFF
--- a/app/src/main/res/layout/pager_photo_item.xml
+++ b/app/src/main/res/layout/pager_photo_item.xml
@@ -4,8 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/photo_holder"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:animateLayoutChanges="true">
+    android:layout_height="match_parent">
 
     <com.alexvasilkov.gestures.GestureImageView
         android:id="@+id/gestures_view"

--- a/app/src/main/res/layout/pager_video_item.xml
+++ b/app/src/main/res/layout/pager_video_item.xml
@@ -4,7 +4,6 @@
     android:id="@+id/video_holder"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:animateLayoutChanges="true"
     android:layoutDirection="ltr">
 
     <ImageView


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Set `animateLayoutChanges` to `false` in both photo and video fragments (originally set to `true` in https://github.com/FossifyOrg/Gallery/pull/595). This fixes a bug where the viewpager stops mid-animation between two pages when opening some images.

A side effect of this change is that the extended details bubble will no longer animate when entering/exiting full-screen. The root cause should be fixed instead, but I do not have time to investigate it.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested opening images

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Not tracked. The bug was introduced in https://github.com/FossifyOrg/Gallery/pull/595.

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
