### PR TITLE
fix: cleanup resources after capturing current filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed overlap between extended details and bottom actions ([#418])
 - Fixed loading big JXL images ([#622])
+- Fixed non-functional filter in image editor ([#718])
 
 ## [1.7.0] - 2025-10-16
 ### Added
@@ -203,6 +204,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#630]: https://github.com/FossifyOrg/Gallery/issues/630
 [#642]: https://github.com/FossifyOrg/Gallery/issues/642
 [#648]: https://github.com/FossifyOrg/Gallery/issues/648
+[#718]: https://github.com/FossifyOrg/Gallery/issues/718
 
 [Unreleased]: https://github.com/FossifyOrg/Gallery/compare/1.7.0...HEAD
 [1.7.0]: https://github.com/FossifyOrg/Gallery/compare/1.6.0...1.7.0

--- a/app/src/main/kotlin/org/fossify/gallery/activities/EditActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/EditActivity.kt
@@ -411,11 +411,12 @@ class EditActivity : SimpleActivity() {
     }
 
     private fun withFilteredImage(callback: (Bitmap) -> Unit) {
-        val currentFilter = getFiltersAdapter()?.getCurrentFilter() ?: return
+        val currentFilter = getFiltersAdapter()?.getCurrentFilter()?.filter ?: return
+        freeMemory()
         ensureBackgroundThread {
             try {
                 val original = getOriginalBitmap()
-                currentFilter.filter.processFilter(original)
+                currentFilter.processFilter(original)
                 callback(original)
             } catch (_: OutOfMemoryError) {
                 toast(org.fossify.commons.R.string.out_of_memory_error)
@@ -425,13 +426,11 @@ class EditActivity : SimpleActivity() {
 
     private fun saveFilteredImage(overwrite: Boolean) {
         if (overwrite) {
-            freeMemory()
             withFilteredImage {
                 saveBitmap(true, it)
             }
         } else {
             resolveSaveAsPath { path ->
-                freeMemory()
                 withFilteredImage {
                     saveBitmapToPath(it, path, showSavingToast = true)
                 }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Moved the `freeMemory()` call so it runs _after_ capturing the current filter from the adapter. This broke due to the saving flow refactor in https://github.com/FossifyOrg/Gallery/pull/686 

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Applying a filter in the image editor (overwrite & save as)
 - Cropping (overwrite & save as)

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Gallery/issues/718

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
