### PR TITLE
refactor: access context safely when fetching extended details

### DIFF
--- a/app/src/main/kotlin/org/fossify/gallery/fragments/ViewPagerFragment.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/fragments/ViewPagerFragment.kt
@@ -93,7 +93,14 @@ abstract class ViewPagerFragment : Fragment() {
         return details.toString().trim()
     }
 
-    fun getPathToLoad(medium: Medium) = if (context?.isPathOnOTG(medium.path) == true) medium.path.getOTGPublicPath(context!!) else medium.path
+    fun getPathToLoad(medium: Medium): String {
+        val context = context ?: return medium.path
+        return if (context.isPathOnOTG(medium.path)) {
+            medium.path.getOTGPublicPath(context)
+        } else {
+            medium.path
+        }
+    }
 
     private fun getResolution(medium: Medium, file: File): String? {
         if (medium.name.endsWith(".jxl",ignoreCase = true)) {


### PR DESCRIPTION
This fixes `NullPointerException` in some cases, especially after https://github.com/FossifyOrg/Gallery/pull/731.