### PR TITLE
fix: remove insets listeners for full-screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed missing resolution info in extended details for JXL images ([#659])
 - Fixed Gallery not appearing when opening photos from LineageOS Camera ([#411])
+- Fixed full-screen view not working properly on some devices ([#743])
 
 ## [1.8.0] - 2025-10-29
 ### Changed
@@ -213,6 +214,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#648]: https://github.com/FossifyOrg/Gallery/issues/648
 [#659]: https://github.com/FossifyOrg/Gallery/issues/659
 [#718]: https://github.com/FossifyOrg/Gallery/issues/718
+[#743]: https://github.com/FossifyOrg/Gallery/issues/743
 
 [Unreleased]: https://github.com/FossifyOrg/Gallery/compare/1.8.0...HEAD
 [1.8.0]: https://github.com/FossifyOrg/Gallery/compare/1.7.0...1.8.0

--- a/app/src/main/kotlin/org/fossify/gallery/activities/PhotoVideoActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/PhotoVideoActivity.kt
@@ -8,8 +8,6 @@ import android.os.Bundle
 import android.provider.MediaStore
 import android.text.Html
 import androidx.core.graphics.drawable.toDrawable
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import org.fossify.commons.dialogs.PropertiesDialog
 import org.fossify.commons.extensions.beGone
 import org.fossify.commons.extensions.beVisible
@@ -268,18 +266,6 @@ open class PhotoVideoActivity : SimpleActivity(), ViewPagerFragment.FragmentList
             val attributes = window.attributes
             attributes.screenBrightness = 1f
             window.attributes = attributes
-        }
-
-        ViewCompat.setOnApplyWindowInsetsListener(binding.fragmentHolder) { _, insets ->
-            val systemBarsVisible = insets.isVisible(
-                WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.navigationBars()
-            )
-            val fullscreen = !systemBarsVisible
-            if (mIsFullScreen != fullscreen) {
-                mIsFullScreen = fullscreen
-                mFragment?.fullscreenToggled(fullscreen)
-            }
-            insets
         }
 
         initBottomActions()

--- a/app/src/main/kotlin/org/fossify/gallery/activities/ViewPagerActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/ViewPagerActivity.kt
@@ -27,8 +27,6 @@ import android.view.WindowManager
 import android.view.animation.DecelerateInterpolator
 import android.widget.Toast
 import androidx.core.graphics.drawable.toDrawable
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.exifinterface.media.ExifInterface
 import androidx.print.PrintHelper
 import androidx.viewpager.widget.ViewPager
@@ -525,18 +523,6 @@ class ViewPagerActivity : SimpleActivity(), ViewPager.OnPageChangeListener, View
                     fragmentClicked()
                 }, HIDE_SYSTEM_UI_DELAY)
             }
-        }
-
-        ViewCompat.setOnApplyWindowInsetsListener(binding.fragmentHolder) { _, insets ->
-            val systemBarsVisible = insets.isVisible(
-                WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.navigationBars()
-            )
-            val fullscreen = !systemBarsVisible
-            if (mIsFullScreen != fullscreen) {
-                mIsFullScreen = fullscreen
-                checkSystemUI()
-            }
-            insets
         }
 
         if (


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Fixed the incorrect full-screen state by removing the listeners for the system bar visibility insets. They don't seem necessary now.

One "side-effect" of this change is that slideshows aren't linked to the system bar visibility, which I think is acceptable.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Entering/existing full-screen
 - Automatic full-screen option
 - Slideshows
 - Closing/reopening the app when displaying content full-screen

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Gallery/issues/743

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
