### PR TITLE
fix: apply bottom insets padding on set wallpaper screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed extended details showing up in full-screen in some cases ([#734])
 - Fixed full-screen view not working properly on some devices ([#743])
 - Fixed full-screen requiring double taps in some cases ([#734])
+- Fixed overlap between bottom actions and system bar when setting wallpaper ([#747])
 
 ## [1.8.0] - 2025-10-29
 ### Changed
@@ -218,6 +219,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#718]: https://github.com/FossifyOrg/Gallery/issues/718
 [#734]: https://github.com/FossifyOrg/Gallery/issues/734
 [#743]: https://github.com/FossifyOrg/Gallery/issues/743
+[#747]: https://github.com/FossifyOrg/Gallery/issues/747
 
 [Unreleased]: https://github.com/FossifyOrg/Gallery/compare/1.8.0...HEAD
 [1.8.0]: https://github.com/FossifyOrg/Gallery/compare/1.7.0...1.8.0

--- a/app/src/main/kotlin/org/fossify/gallery/activities/SetWallpaperActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/SetWallpaperActivity.kt
@@ -34,6 +34,9 @@ class SetWallpaperActivity : SimpleActivity(), CropImageView.OnCropImageComplete
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+        setupEdgeToEdge(
+            padBottomSystem = listOf(binding.activitySetWallpaperHolder)
+        )
         setupBottomActions()
 
         if (checkAppSideloading()) {


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Applied bottom insets to the activity content holder view. This screen needs improvements.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Setting wallpaper

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Gallery/issues/747

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
