### PR TITLE
fix: access context safely from background thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed overlap between editor controls and preview ([#752])
+- Fixed crash when viewing photos with extended details enabled ([#754])
 
 ## [1.8.1] - 2025-11-04
 ### Changed
@@ -228,6 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#743]: https://github.com/FossifyOrg/Gallery/issues/743
 [#747]: https://github.com/FossifyOrg/Gallery/issues/747
 [#752]: https://github.com/FossifyOrg/Gallery/issues/752
+[#754]: https://github.com/FossifyOrg/Gallery/issues/754
 
 [Unreleased]: https://github.com/FossifyOrg/Gallery/compare/1.8.1...HEAD
 [1.8.1]: https://github.com/FossifyOrg/Gallery/compare/1.8.0...1.8.1

--- a/app/src/main/kotlin/org/fossify/gallery/fragments/PhotoFragment.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/fragments/PhotoFragment.kt
@@ -907,7 +907,8 @@ class PhotoFragment : ViewPagerFragment() {
                     binding.photoDetails.apply {
                         text = details
                         beVisibleIf(text.isNotEmpty())
-                        alpha = if (!requireContext().config.hideExtendedDetails || !mIsFullscreen) 1f else 0f
+                        val hideExtendedDetails = context?.config?.hideExtendedDetails == true
+                        alpha = if (!hideExtendedDetails || !mIsFullscreen) 1f else 0f
                     }
                 }
             }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Replaced `requireContext()` with a safe call to avoid `java.lang.IllegalStateException` when fragment is detached.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 -  Viewing photos and videos
 
#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Gallery/issues/754

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
