### PR TITLE
fix: prevent invalid insets when notch preference is toggled

### DIFF
--- a/app/src/main/kotlin/org/fossify/gallery/activities/BaseViewerActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/BaseViewerActivity.kt
@@ -5,7 +5,11 @@ import android.view.View
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.appbar.AppBarLayout
+import kotlinx.coroutines.launch
 import org.fossify.commons.extensions.updatePaddingWithBase
 import org.fossify.gallery.extensions.config
 
@@ -21,6 +25,17 @@ abstract class BaseViewerActivity : SimpleActivity() {
             setupEdgeToEdge(insets)
             insets
         }
+        registerShowNotchCollector(contentRoot)
+    }
+
+    private fun registerShowNotchCollector(view: View) {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                config.showNotchFlow.collect {
+                    view.requestApplyInsets()
+                }
+            }
+        }
     }
 
     private fun setupEdgeToEdge(insets: WindowInsetsCompat) {
@@ -32,6 +47,8 @@ abstract class BaseViewerActivity : SimpleActivity() {
                 left = systemAndCutout.left,
                 right = systemAndCutout.right
             )
+
+            contentHolder.updatePaddingWithBase(left = 0, top = 0, right = 0, bottom = 0)
         } else {
             val system = insets.getInsetsIgnoringVisibility(Type.systemBars())
             val cutout = insets.getInsetsIgnoringVisibility(Type.displayCutout())

--- a/app/src/main/kotlin/org/fossify/gallery/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/helpers/Config.kt
@@ -5,7 +5,11 @@ import android.content.res.Configuration
 import android.os.Environment
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import org.fossify.commons.helpers.*
+import org.fossify.commons.helpers.BaseConfig
+import org.fossify.commons.helpers.PROTECTION_PATTERN
+import org.fossify.commons.helpers.SORT_BY_DATE_MODIFIED
+import org.fossify.commons.helpers.SORT_DESCENDING
+import org.fossify.commons.helpers.VIEW_TYPE_GRID
 import org.fossify.gallery.R
 import org.fossify.gallery.models.AlbumCover
 import java.util.Arrays
@@ -527,6 +531,8 @@ class Config(context: Context) : BaseConfig(context) {
     var showNotch: Boolean
         get() = prefs.getBoolean(SHOW_NOTCH, true)
         set(showNotch) = prefs.edit().putBoolean(SHOW_NOTCH, showNotch).apply()
+
+    val showNotchFlow = ::showNotch.asFlowNonNull(true)
 
     var spamFoldersChecked: Boolean
         get() = prefs.getBoolean(SPAM_FOLDERS_CHECKED, false)


### PR DESCRIPTION
Double paddings were applied when **Show notch if available** preference was toggled without restarting the preview screen.