### PR TITLE
fix: show stroke around on color picker button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed invisible color picker button in black themes ([#337]) 
 
 ## [1.10.0] - 2025-12-16
 ### Added
@@ -231,6 +233,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#241]: https://github.com/FossifyOrg/Gallery/issues/241
 [#275]: https://github.com/FossifyOrg/Gallery/issues/275
 [#325]: https://github.com/FossifyOrg/Gallery/issues/325
+[#337]: https://github.com/FossifyOrg/Gallery/issues/337
 [#362]: https://github.com/FossifyOrg/Gallery/issues/362
 [#365]: https://github.com/FossifyOrg/Gallery/issues/365
 [#375]: https://github.com/FossifyOrg/Gallery/issues/375

--- a/app/src/main/kotlin/org/fossify/gallery/activities/EditActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/EditActivity.kt
@@ -26,6 +26,7 @@ import com.zomato.photofilters.FilterPack
 import com.zomato.photofilters.imageprocessors.Filter
 import org.fossify.commons.dialogs.ColorPickerDialog
 import org.fossify.commons.extensions.applyColorFilter
+import org.fossify.commons.extensions.setFillWithStroke
 import org.fossify.commons.extensions.beGone
 import org.fossify.commons.extensions.beGoneIf
 import org.fossify.commons.extensions.beVisible
@@ -813,7 +814,8 @@ class EditActivity : BaseCropActivity() {
 
     private fun updateDrawColor(color: Int) {
         drawColor = color
-        binding.bottomEditorDrawActions.bottomDrawColor.applyColorFilter(color)
+        binding.bottomEditorDrawActions.bottomDrawColor
+            .setFillWithStroke(color, getProperBackgroundColor())
         config.lastEditorDrawColor = color
         binding.editorDrawCanvas.updateColor(color)
     }

--- a/app/src/main/res/layout/bottom_editor_draw_actions.xml
+++ b/app/src/main/res/layout/bottom_editor_draw_actions.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/bottom_editor_draw_actions_wrapper"
     android:layout_width="match_parent"
     android:layout_height="@dimen/bottom_actions_height"
@@ -38,10 +39,10 @@
         android:clickable="false"
         android:contentDescription="@null"
         android:padding="@dimen/small_margin"
-        android:src="@drawable/circle_background"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toLeftOf="@+id/bottom_draw_undo"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/circle_background" />
 
     <ImageView
         android:id="@+id/bottom_draw_undo"


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Added a stroke around the color picker button

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested color picker in themes with black background

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Gallery/issues/337

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
