### PR TITLE
fix: prevent video from playing while seeking if paused

### DIFF
--- a/app/src/main/kotlin/org/fossify/gallery/activities/VideoPlayerActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/VideoPlayerActivity.kt
@@ -783,7 +783,9 @@ open class VideoPlayerActivity : BaseViewerActivity(), SeekBar.OnSeekBarChangeLi
         mExoPlayer?.playWhenReady = false
         mPlayWhenReadyHandler.removeCallbacksAndMessages(null)
         mPlayWhenReadyHandler.postDelayed({
-            mExoPlayer?.playWhenReady = true
+            if (mIsPlaying) {
+                mExoPlayer?.playWhenReady = true
+            }
         }, PLAY_WHEN_READY_DRAG_DELAY)
     }
 


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Fixed an issue where a paused video would automatically resume playing if the user held the seekbar for more than 100ms.
- Modified `resetPlayWhenReady()` in `VideoPlayerActivity.kt` to check `mIsPlaying` before setting `playWhenReady = true`. This ensures the video remains paused if it was already paused before seeking.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Replicated the issue on the current version: paused a video, held the seekbar, and observed it auto-playing.
 - Applied the fix and verified: paused a video, held the seekbar, and confirmed it remained paused after releasing.
 - Verified that playing videos still resume correctly after seeking.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #831

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
