### PR TITLE
fix: never show "Rename" as an action button

### DIFF
--- a/app/src/main/res/menu/cab_directories.xml
+++ b/app/src/main/res/menu/cab_directories.xml
@@ -43,9 +43,8 @@
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/cab_rename"
-        android:icon="@drawable/ic_rename_vector"
         android:title="@string/rename"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="never" />
     <item
         android:id="@+id/cab_hide"
         android:icon="@drawable/ic_hide_vector"

--- a/app/src/main/res/menu/cab_media.xml
+++ b/app/src/main/res/menu/cab_media.xml
@@ -45,9 +45,8 @@
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/cab_rename"
-        android:icon="@drawable/ic_rename_vector"
         android:title="@string/rename"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="never" />
     <item
         android:id="@+id/cab_hide"
         android:icon="@drawable/ic_hide_vector"

--- a/app/src/main/res/menu/menu_viewpager.xml
+++ b/app/src/main/res/menu/menu_viewpager.xml
@@ -43,9 +43,8 @@
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/menu_rename"
-        android:icon="@drawable/ic_rename_vector"
         android:title="@string/rename"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="never" />
     <item
         android:id="@+id/menu_hide"
         android:icon="@drawable/ic_hide_vector"


### PR DESCRIPTION
The original cursor icon was outdated. Pencil icon is used for content editing.
