### PR TITLE
fix(storage): avoid invalid MediaStore URI on overwrite save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed invalid MediaStore URI crash when overwriting edited images on scoped-storage devices ([#1031])
 
 ## [1.13.1] - 2026-02-14
 ### Changed

--- a/app/src/main/kotlin/org/fossify/gallery/extensions/Activity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/extensions/Activity.kt
@@ -1019,11 +1019,18 @@ fun BaseSimpleActivity.ensureWritablePath(
     }
 
     fun requestGrantsThenProceed() {
-        if (isRPlus() && !isExternalStorageManager()) {
-            val fileDirItem = arrayListOf(File(targetPath).toFileDirItem(this))
-            val fileUris = getFileUrisFromFileDirItems(fileDirItem)
-            updateSDK30Uris(fileUris) { success ->
-                if (success) proceedAfterGrants() else onCancel?.invoke()
+        if (isRPlus() && !isExternalStorageManager() && getDoesFilePathExist(targetPath)) {
+            val fileDirItems = arrayListOf(File(targetPath).toFileDirItem(this))
+            resolveMediaStoreUris(fileDirItems) { resolution ->
+                val fileUris = resolution.uris
+                if (fileUris.isEmpty()) {
+                    proceedAfterGrants()
+                    return@resolveMediaStoreUris
+                }
+
+                updateSDK30Uris(fileUris) { success ->
+                    if (success) proceedAfterGrants() else onCancel?.invoke()
+                }
             }
         } else {
             proceedAfterGrants()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ exif = "1.0.1"
 #Room
 room = "2.8.4"
 #Fossify
-commons = "6.1.6"
+commons = "7.0.0"
 #Gradle4
 gradlePlugins-agp = "9.2.0"
 #Other


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Updates Gallery to use commons `7.0.0`, which includes safe MediaStore URI resolution for scoped-storage operations.
- Changes overwrite-save permission handling to request Android 11+ scoped-storage write grants only when the target file already exists.
- Resolves the target file through MediaStore before calling `MediaStore.createWriteRequest(...)`, avoiding invalid URIs like `content://media/external/images/media/0`.
- Allows new-file save-as paths to proceed without a write request for a non-existent MediaStore item.

This fixes overwrite-save flows such as editing/cropping an image and saving over the original on scoped-storage devices.

Depends on FossifyOrg/commons#339.

#### Tests performed
- Clean clone of this branch on the Android build host.
- `./gradlew :app:assembleFossDebug`
- Installed the debug APK on an Android 16 Pixel device.
- Runtime-tested the crop overwrite-save flow; save succeeds without `Invalid Uri: content://media/external/images/media/0`.

#### Before & after preview
N/A — no UI changes.

#### Closes the following issue(s)
- Closes #1031

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.
