### PR TITLE
Hide 'Move to' action for media in recycle bin

### DIFF
--- a/app/src/main/kotlin/org/fossify/gallery/activities/ViewPagerActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/ViewPagerActivity.kt
@@ -299,7 +299,7 @@ class ViewPagerActivity : BaseViewerActivity(), ViewPager.OnPageChangeListener, 
                 findItem(R.id.menu_set_as).isVisible = visibleBottomActions and BOTTOM_ACTION_SET_AS == 0
                 findItem(R.id.menu_copy_to_clipboard).isVisible = currentMedium.isImage()
                 findItem(R.id.menu_copy_to).isVisible = visibleBottomActions and BOTTOM_ACTION_COPY == 0
-                findItem(R.id.menu_move_to).isVisible = visibleBottomActions and BOTTOM_ACTION_MOVE == 0
+                findItem(R.id.menu_move_to).isVisible = visibleBottomActions and BOTTOM_ACTION_MOVE == 0 && !currentMedium.getIsInRecycleBin()
                 findItem(R.id.menu_save_as).isVisible = rotationDegrees != 0
                 findItem(R.id.menu_print).isVisible = currentMedium.isImage() || currentMedium.isRaw()
                 findItem(R.id.menu_resize).isVisible = visibleBottomActions and BOTTOM_ACTION_RESIZE == 0 && currentMedium.isImage()

--- a/app/src/main/kotlin/org/fossify/gallery/activities/ViewPagerActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/ViewPagerActivity.kt
@@ -299,7 +299,8 @@ class ViewPagerActivity : BaseViewerActivity(), ViewPager.OnPageChangeListener, 
                 findItem(R.id.menu_set_as).isVisible = visibleBottomActions and BOTTOM_ACTION_SET_AS == 0
                 findItem(R.id.menu_copy_to_clipboard).isVisible = currentMedium.isImage()
                 findItem(R.id.menu_copy_to).isVisible = visibleBottomActions and BOTTOM_ACTION_COPY == 0
-                findItem(R.id.menu_move_to).isVisible = visibleBottomActions and BOTTOM_ACTION_MOVE == 0 && !currentMedium.getIsInRecycleBin()
+                findItem(R.id.menu_move_to).isVisible =
+                    visibleBottomActions and BOTTOM_ACTION_MOVE == 0 && !currentMedium.getIsInRecycleBin()
                 findItem(R.id.menu_save_as).isVisible = rotationDegrees != 0
                 findItem(R.id.menu_print).isVisible = currentMedium.isImage() || currentMedium.isRaw()
                 findItem(R.id.menu_resize).isVisible = visibleBottomActions and BOTTOM_ACTION_RESIZE == 0 && currentMedium.isImage()


### PR DESCRIPTION
Fixes #692.

Hides the "Move to" action in the fullscreen viewer (ViewPagerActivity)
when the media is in the recycle bin, where moving isn't supported and
currently just shows an error. This matches the existing behavior in the
grid selection (MediaAdapter) and the sibling menu items here
(menu_rename, menu_hide, menu_add_to_favorites).

Note: I wasn't able to run the app locally yet (Android SDK not set up),
but the change mirrors the established pattern in the same function.
Happy to add screenshots if needed.
