### PR TITLE
fix: respect square thumbnail style in list view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed list-view thumbnails showing rounded corners when the square thumbnail style was selected ([#589])
 
 ## [1.13.1] - 2026-02-14
 ### Changed
@@ -287,6 +289,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#565]: https://github.com/FossifyOrg/Gallery/issues/565
 [#567]: https://github.com/FossifyOrg/Gallery/issues/567
 [#568]: https://github.com/FossifyOrg/Gallery/issues/568
+[#589]: https://github.com/FossifyOrg/Gallery/issues/589
 [#621]: https://github.com/FossifyOrg/Gallery/issues/621
 [#622]: https://github.com/FossifyOrg/Gallery/issues/622
 [#630]: https://github.com/FossifyOrg/Gallery/issues/630

--- a/app/src/main/kotlin/org/fossify/gallery/adapters/DirectoryAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/adapters/DirectoryAdapter.kt
@@ -879,8 +879,8 @@ class DirectoryAdapter(
             } else {
                 dirLock.beGone()
                 val roundedCorners = when {
-                    isListViewType -> ROUNDED_CORNERS_SMALL
                     folderStyle == FOLDER_STYLE_SQUARE -> ROUNDED_CORNERS_NONE
+                    isListViewType -> ROUNDED_CORNERS_SMALL
                     else -> ROUNDED_CORNERS_BIG
                 }
 

--- a/app/src/main/kotlin/org/fossify/gallery/adapters/MediaAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/adapters/MediaAdapter.kt
@@ -725,9 +725,9 @@ class MediaAdapter(
             }
 
             val roundedCorners = when {
+                !config.fileRoundedCorners -> ROUNDED_CORNERS_NONE
                 isListViewType -> ROUNDED_CORNERS_SMALL
-                config.fileRoundedCorners -> ROUNDED_CORNERS_BIG
-                else -> ROUNDED_CORNERS_NONE
+                else -> ROUNDED_CORNERS_BIG
             }
 
             mediumThumbnail.setBackgroundResource(


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
List-view thumbnails always rendered with rounded corners even when the user selected the square thumbnail style, while grid view respected the setting. In both `MediaAdapter` and `DirectoryAdapter`, the `roundedCorners` `when` evaluated the `isListViewType` branch first, so list view unconditionally forced `ROUNDED_CORNERS_SMALL` and never consulted the square setting (`config.fileRoundedCorners == false` for media, `folderStyle == FOLDER_STYLE_SQUARE` for folders).

The fix reorders the branches so the square-style check runs first. When the user picks square, thumbnails now get `ROUNDED_CORNERS_NONE` in both list and grid views; otherwise the previous behavior is preserved (list = small radius, grid = big radius). This is a minimal, behavior-preserving reorder with no layout or resource changes.

#### Tests performed
Built the `fossDebug` variant and verified on an Android 15 (API 35) emulator:

Seeded 5 images; set File thumbnail style=Square (rounded off), switched folder to List view -> thumbnails square-cornered; changed style to Rounded corners -> List view thumbnails rounded. Style now respected in list view. Folder thumbnails also square in grid (Folder style=Square).

Also confirmed `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).

#### Closes the following issue(s)
- Closes #589

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually tested my changes on device/emulator.
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
