### PR TITLE
fix: hide non-functional "Move to" action in the recycle bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Hide the non-functional "Move to" action when viewing items in the recycle bin ([#692])
 
 ## [1.13.1] - 2026-02-14
 ### Changed
@@ -294,6 +296,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#648]: https://github.com/FossifyOrg/Gallery/issues/648
 [#659]: https://github.com/FossifyOrg/Gallery/issues/659
 [#666]: https://github.com/FossifyOrg/Gallery/issues/666
+[#692]: https://github.com/FossifyOrg/Gallery/issues/692
 [#718]: https://github.com/FossifyOrg/Gallery/issues/718
 [#734]: https://github.com/FossifyOrg/Gallery/issues/734
 [#743]: https://github.com/FossifyOrg/Gallery/issues/743

--- a/app/src/main/kotlin/org/fossify/gallery/activities/ViewPagerActivity.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/activities/ViewPagerActivity.kt
@@ -299,7 +299,8 @@ class ViewPagerActivity : BaseViewerActivity(), ViewPager.OnPageChangeListener, 
                 findItem(R.id.menu_set_as).isVisible = visibleBottomActions and BOTTOM_ACTION_SET_AS == 0
                 findItem(R.id.menu_copy_to_clipboard).isVisible = currentMedium.isImage()
                 findItem(R.id.menu_copy_to).isVisible = visibleBottomActions and BOTTOM_ACTION_COPY == 0
-                findItem(R.id.menu_move_to).isVisible = visibleBottomActions and BOTTOM_ACTION_MOVE == 0
+                findItem(R.id.menu_move_to).isVisible =
+                    visibleBottomActions and BOTTOM_ACTION_MOVE == 0 && !currentMedium.getIsInRecycleBin()
                 findItem(R.id.menu_save_as).isVisible = rotationDegrees != 0
                 findItem(R.id.menu_print).isVisible = currentMedium.isImage() || currentMedium.isRaw()
                 findItem(R.id.menu_resize).isVisible = visibleBottomActions and BOTTOM_ACTION_RESIZE == 0 && currentMedium.isImage()
@@ -1038,7 +1039,9 @@ class ViewPagerActivity : BaseViewerActivity(), ViewPager.OnPageChangeListener, 
             checkMediaManagementAndCopy(true)
         }
 
-        binding.bottomActions.bottomMove.beVisibleIf(visibleBottomActions and BOTTOM_ACTION_MOVE != 0)
+        binding.bottomActions.bottomMove.beVisibleIf(
+            visibleBottomActions and BOTTOM_ACTION_MOVE != 0 && currentMedium?.getIsInRecycleBin() == false
+        )
         binding.bottomActions.bottomMove.setOnLongClickListener { toast(org.fossify.commons.R.string.move); true }
         binding.bottomActions.bottomMove.setOnClickListener {
             moveFileTo()


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
In the fullscreen viewer (`ViewPagerActivity`), the overflow **Move to** item and the opt-in bottom-action **Move** button were shown even when viewing an item inside the recycle bin. Moving is not supported from the bin: tapping **Move to** calls `copyMoveTo()`, which detects `currPath.startsWith(recycleBinPath)` and only shows the toast "Moving recycle bin items is disabled. Please use Restore." before returning. So the action appeared functional but did nothing (this is the German toast shown in the issue screenshot).

This adds the missing `!currentMedium.getIsInRecycleBin()` guard to both the overflow item (`menu_move_to`) and the bottom-action Move button, matching the pattern already used by the neighbouring rename / hide / unhide / favorite items and the `bottomRename` / `bottomFavorite` buttons, and consistent with the grid CAB which already hides `cab_move_to` in the bin.

**Copy to** is intentionally left visible, because copying from the recycle bin is functional — `copyMoveTo()` blocks only the move operation.

#### Tests performed
Built the `fossDebug` variant and verified on an Android 15 (API 35) emulator:

Deleted an image to recycle bin; opened it fullscreen; overflow menu had NO 'Move to' (count 0) but had 'Copy to' and 'Restore this file'. Regression: opened a normal (non-bin) image fullscreen -> overflow HAS 'Move to' (count 1) plus 'Rename'.

Also confirmed `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).

#### Closes the following issue(s)
- Closes #692

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually tested my changes on device/emulator.
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
