### PR TITLE
fix: show Properties for Recycle Bin and Favorites folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed the Properties action doing nothing on the Recycle Bin and Favorites folders ([#976])
 
 ## [1.13.1] - 2026-02-14
 ### Changed
@@ -310,6 +312,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#876]: https://github.com/FossifyOrg/Gallery/issues/876
 [#917]: https://github.com/FossifyOrg/Gallery/issues/917
 [#925]: https://github.com/FossifyOrg/Gallery/issues/925
+[#976]: https://github.com/FossifyOrg/Gallery/issues/976
 
 [Unreleased]: https://github.com/FossifyOrg/Gallery/compare/1.13.1...HEAD
 [1.13.1]: https://github.com/FossifyOrg/Gallery/compare/1.13.0...1.13.1

--- a/app/src/main/kotlin/org/fossify/gallery/adapters/DirectoryAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/adapters/DirectoryAdapter.kt
@@ -79,7 +79,9 @@ import org.fossify.gallery.extensions.emptyAndDisableTheRecycleBin
 import org.fossify.gallery.extensions.emptyTheRecycleBin
 import org.fossify.gallery.extensions.favoritesDB
 import org.fossify.gallery.extensions.fixDateTaken
+import org.fossify.gallery.extensions.getFavoritePaths
 import org.fossify.gallery.extensions.getShortcutImage
+import org.fossify.gallery.extensions.getUpdatedDeletedMedia
 import org.fossify.gallery.extensions.isThisOrParentFolderHidden
 import org.fossify.gallery.extensions.loadImage
 import org.fossify.gallery.extensions.mediaDB
@@ -292,8 +294,10 @@ class DirectoryAdapter(
     private fun showProperties() {
         if (selectedKeys.size <= 1) {
             val path = getFirstSelectedItemPath() ?: return
-            if (path != FAVORITES && path != RECYCLE_BIN) {
-                activity.handleLockedFolderOpening(path) { success ->
+            when (path) {
+                FAVORITES -> showVirtualFolderProperties { activity.getFavoritePaths() }
+                RECYCLE_BIN -> showVirtualFolderProperties { activity.getUpdatedDeletedMedia().map { it.path } }
+                else -> activity.handleLockedFolderOpening(path) { success ->
                     if (success) {
                         PropertiesDialog(activity, path, config.shouldShowHidden)
                     }
@@ -303,6 +307,19 @@ class DirectoryAdapter(
             PropertiesDialog(activity, getSelectedPaths().filter {
                 it != FAVORITES && it != RECYCLE_BIN && !config.isFolderProtected(it)
             }.toMutableList(), config.shouldShowHidden)
+        }
+    }
+
+    // Recycle Bin and Favorites are virtual folders without a real path, so gather the
+    // actual media file paths on a background thread and show them in the properties dialog.
+    private fun showVirtualFolderProperties(getPaths: () -> List<String>) {
+        ensureBackgroundThread {
+            val paths = getPaths()
+            if (paths.isNotEmpty()) {
+                activity.runOnUiThread {
+                    PropertiesDialog(activity, paths, config.shouldShowHidden)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
Long-pressing the **Recycle Bin** or **Favorites** folder and tapping the Properties (i) icon did nothing. `DirectoryAdapter.showProperties()` opened the single-path `PropertiesDialog` only inside an `if (path != FAVORITES && path != RECYCLE_BIN)` guard with no `else` branch, so both virtual folders fell through and the action was a silent no-op. The guard existed because these folders have virtual DB paths (`"recycle_bin"` / `"favorites"`) that are not real files, and the single-path `PropertiesDialog` rejects non-existent paths.

The fix gathers the real underlying media paths and shows them in the multi-path `PropertiesDialog`:
- Recycle Bin: `getUpdatedDeletedMedia()` (rewrites the virtual prefix to the actual `recycleBinPath` location).
- Favorites: `getFavoritePaths()` (`FavoritesDao.getValidFavoritePaths()`).

Both helpers run Room queries and `GalleryDatabase` is built without `allowMainThreadQueries()`, so they must run off the UI thread — otherwise Room throws and the helpers silently return empty lists. They are therefore executed on a background thread via `ensureBackgroundThread`, then the dialog is shown back on the UI thread. An `isNotEmpty()` guard avoids passing an empty list to the multi-path constructor (which indexes `fileDirItems[0]`).

#### Tests performed
Built the `fossDebug` variant and verified on an Android 15 (API 35) emulator:

Created a Favorite and a recycle-bin item; on folders screen long-pressed 'Recycle bin' -> Properties opened a dialog (Items selected 1 / Size 1.4 MB / Files 1). Repeated for 'Favorites' -> Properties dialog opened. Previously nothing happened.

Also confirmed `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).

#### Closes the following issue(s)
- Closes #976

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually tested my changes on device/emulator.
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
