### PR TITLE
fix: reset saved video position after playback ends

### DIFF
--- a/app/src/main/kotlin/org/fossify/gallery/fragments/VideoFragment.kt
+++ b/app/src/main/kotlin/org/fossify/gallery/fragments/VideoFragment.kt
@@ -913,6 +913,7 @@ class VideoFragment : ViewPagerFragment(), TextureView.SurfaceTextureListener,
             return
         }
 
+        mConfig.removeLastVideoPosition(mMedium.path)
         mCurrTime = mExoPlayer!!.duration
         if (listener?.videoEnded() == false && mConfig.loopVideos) {
             playVideo()


### PR DESCRIPTION
Closes #969

Clears the saved position when an inline gallery video reaches the end, matching the standalone player.

Checked with `./gradlew :app:detekt`.
